### PR TITLE
Added increment and decrement functions

### DIFF
--- a/PowerFunctions.cpp
+++ b/PowerFunctions.cpp
@@ -34,6 +34,22 @@ void PowerFunctions::single_pwm(uint8_t output, uint8_t pwm) {
   toggle();
 }
 
+void PowerFunctions::single_increment(uint8_t output){
+  _nib1 = _toggle | _channel;
+  _nib2 = SINGLE_EXT | output;
+  _nib3 = 0x4;
+  send();
+  toggle();
+}
+
+void PowerFunctions::single_decrement(uint8_t output){
+  _nib1 = _toggle | _channel;
+  _nib2 = SINGLE_EXT | output;
+  _nib3 = 0x5;
+  send();
+  toggle();
+}
+
 // Combo PWM mode
 void PowerFunctions::combo_pwm(uint8_t blue_speed, uint8_t red_speed)
 {

--- a/PowerFunctions.h
+++ b/PowerFunctions.h
@@ -8,6 +8,7 @@
 #define SINGLE_PIN_CONTINUOUS 0x2
 #define SINGLE_PIN_TIMEOUT 0x3
 #define SINGLE_OUTPUT 0x4
+#define SINGLE_EXT 0x6
 #define ESCAPE 0x4
 
 #define IR_CYCLES(num) (uint16_t) ((1.0/38000.0) * 1000 * 1000 * num)
@@ -57,6 +58,8 @@ class PowerFunctions
 	public:
   	PowerFunctions(uint8_t, uint8_t);
     void single_pwm(uint8_t, uint8_t);
+    void single_increment(uint8_t);
+    void single_decrement(uint8_t);
     void red_pwm(uint8_t);
     void blue_pwm(uint8_t);
     void combo_pwm(uint8_t, uint8_t);


### PR DESCRIPTION
Hi there,
   I've added a couple of extra functions to your library, to include the single increment and decrement commands. 

I needed them to bypass the full speed timeout feature built into the lego power function receivers. I used your library in the making the control of a monorail mounted video camera for an recent instillation.

more information, pictures and video links can be found here.
https://github.com/paulhayes/DarkRide
