### PR TITLE
Support sending beacon messages to EV3 IR sensor

### DIFF
--- a/PowerFunctions.cpp
+++ b/PowerFunctions.cpp
@@ -59,6 +59,14 @@ void PowerFunctions::combo_pwm(uint8_t blue_speed, uint8_t red_speed)
   send();
 }
 
+void PowerFunctions::send_beacon()
+{
+  _nib1 = ESCAPE | _channel;
+  _nib2 = 0x0;
+  _nib3 = 0x0;
+  send();
+}
+
 //
 // Private methods
 //

--- a/PowerFunctions.h
+++ b/PowerFunctions.h
@@ -63,6 +63,7 @@ class PowerFunctions
     void red_pwm(uint8_t);
     void blue_pwm(uint8_t);
     void combo_pwm(uint8_t, uint8_t);
+    void send_beacon();
 
   private:
     void pause(uint8_t);


### PR DESCRIPTION
The EV3 IR Sensor/Remote has a Beacon mode where the Remote will send a constant beacon signal and the Sensor can detect the distance and direction to the beacon. This PR adds the ability to send the beacon signal from the PowerFunctions library.

Usage:

    #include "PowerFunctions.h"

    PowerFunctions pf(3, 0);

    void loop() {
        delay(220);
        pf.send_beacon();
    }